### PR TITLE
クライアントサイドの、細かいfixをまとめて行いました。#18 #17

### DIFF
--- a/bookshelf_app/CallAPIRapper.js
+++ b/bookshelf_app/CallAPIRapper.js
@@ -75,8 +75,11 @@ const CallAPIRapper = {
   },
   async changeBookReadState(book, new_read_state) {
     try {
+      //サーバーサイドへはbook.detailを送らないようにします。
+      let send_book = JSON.parse(JSON.stringify(book));
+      send_book.detail = undefined;
       let send_data = {
-        book: book,
+        book: send_book,
         new_read_state: new_read_state
       };
       const response = await fetch('/api/change_read_state', {
@@ -97,8 +100,11 @@ const CallAPIRapper = {
   },
   async deleteBook(book) {
     try {
+      //サーバーサイドへはbook.detailを送らないようにします。
+      let send_book = JSON.parse(JSON.stringify(book));
+      send_book.detail = undefined;
       let send_data = {
-        book: book
+        book: send_book
       };
       const response = await fetch('/api/delete_book', {
         method: 'POST',

--- a/bookshelf_app/CallAPIRapper.js
+++ b/bookshelf_app/CallAPIRapper.js
@@ -2,7 +2,7 @@
 
 import { getBookJson } from './bookUtil.js';
 const CallAPIRapper = {
-  async loadIsbn() {
+  async loadBooks() {
     try {
       const response = await fetch(`/api/get_have_books`, {
         method: 'GET'
@@ -17,7 +17,7 @@ const CallAPIRapper = {
       return [];
     }
   },
-  async loadIsbnWithSharedId(shared_id) {
+  async loadBooksWithSharedId(shared_id) {
     try {
       const response = await fetch(`/api/get_shared_books/${shared_id}`, {
         method: 'GET'
@@ -44,7 +44,7 @@ const CallAPIRapper = {
       return [];
     }
   },
-  async registerIsbn(inputingIsbn) {
+  async registerNewIsbn(inputingIsbn) {
     try {
       if (inputingIsbn.length === 0) {
         this.setState({
@@ -73,7 +73,7 @@ const CallAPIRapper = {
       };
     }
   },
-  async changeReadState(book, new_read_state) {
+  async changeBookReadState(book, new_read_state) {
     try {
       let send_data = {
         book: book,
@@ -116,7 +116,7 @@ const CallAPIRapper = {
       };
     }
   },
-  async shareUrlCopyToCrip() {
+  async getLoginingUserId() {
     try {
       const response = await fetch(`/api/get_user_id`, {
         method: 'GET'

--- a/bookshelf_app/home.js
+++ b/bookshelf_app/home.js
@@ -36,11 +36,11 @@ class Bookshelf extends React.Component {
       books: [],
       mode_state: 0
     };
-    this.loadIsbn();
+    this.loadBooks();
   }
-  loadIsbn = async () => {
+  loadBooks = async () => {
     try {
-      const books = await CallAPIRapper.loadIsbn();
+      const books = await CallAPIRapper.loadBooks();
       this.setState({
         books: books
       });
@@ -48,7 +48,7 @@ class Bookshelf extends React.Component {
       console.error(error);
     }
   };
-  registerIsbn = async inputingIsbn => {
+  registerNewBook = async inputingIsbn => {
     try {
       if (inputingIsbn.length === 0) {
         this.setState({
@@ -56,7 +56,7 @@ class Bookshelf extends React.Component {
         });
         return;
       }
-      const json = await CallAPIRapper.registerIsbn(inputingIsbn);
+      const json = await CallAPIRapper.registerNewIsbn(inputingIsbn);
       console.log("res: " + json.text);
       if (json.text === 'success') {
         this.setState({
@@ -88,9 +88,9 @@ class Bookshelf extends React.Component {
       });
     }
   };
-  changeReadState = async (index, new_read_state) => {
+  changeBookReadState = async (index, new_read_state) => {
     try {
-      const json = await CallAPIRapper.changeReadState(this.state.books[index], new_read_state);
+      const json = await CallAPIRapper.changeBookReadState(this.state.books[index], new_read_state);
       console.log("res: " + json.text);
       if (json.text === 'success') {
         this.setState({
@@ -147,10 +147,7 @@ class Bookshelf extends React.Component {
   };
   shareUrlCopyToCrip = async () => {
     try {
-      const response = await fetch(`/api/get_user_id`, {
-        method: 'GET'
-      });
-      const json = await response.json();
+      const json = await CallAPIRapper.getLoginingUserId();
       const shareUrl = `${window.location.origin}/shared_books/${json.user_id}`;
       navigator.clipboard.writeText(shareUrl).then(() => {
         console.log(shareUrl + " was copyed");
@@ -178,7 +175,7 @@ class Bookshelf extends React.Component {
           });
         case 1:
           return /*#__PURE__*/React.createElement(BookAddState, {
-            submitOnClick: this.registerIsbn,
+            submitOnClick: this.registerNewBook,
             books: this.state.books
           });
         case 2:
@@ -187,7 +184,7 @@ class Bookshelf extends React.Component {
             changeReadState: index => {
               let read_state = this.state.books[index].read_state;
               let new_read_state = read_state < 2 ? read_state + 1 : 0;
-              this.changeReadState(index, new_read_state);
+              this.changeBookReadState(index, new_read_state);
             }
           });
         case 3:

--- a/bookshelf_app/readOnly.js
+++ b/bookshelf_app/readOnly.js
@@ -7,11 +7,7 @@ class Bookshelf extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      server_response: '',
-      inputingIsbn: '',
       books: [],
-      bookDetails: [],
-      mode_state: 0,
       user_name: ''
     };
     this.loadBooks();

--- a/bookshelf_app/readOnly.js
+++ b/bookshelf_app/readOnly.js
@@ -14,16 +14,13 @@ class Bookshelf extends React.Component {
       mode_state: 0,
       user_name: ''
     };
-    this.loadIsbn();
+    this.loadBooks();
   }
-  async loadIsbn() {
+  async loadBooks() {
     const path = window.location.pathname;
     const shared_id = path.split('/')[2];
     try {
-      const response = await fetch(`/api/get_shared_books/${shared_id}`, {
-        method: 'GET'
-      });
-      const books = await response.json();
+      const books = await CallAPIRapper.loadBooksWithSharedId(shared_id);
       for (const book of books) {
         book.detail = await getBookJson(book.isbn);
       }

--- a/bookshelf_app/src/CallAPIRapper.js
+++ b/bookshelf_app/src/CallAPIRapper.js
@@ -2,7 +2,7 @@
 import { getBookJson } from './bookUtil.js';
 
 const CallAPIRapper = {
-    async loadIsbn() {
+    async loadBooks() {
         try {
             const response = await fetch(`/api/get_have_books`, {
                 method: 'GET',
@@ -18,7 +18,7 @@ const CallAPIRapper = {
         }
     },
 
-    async loadIsbnWithSharedId(shared_id) {
+    async loadBooksWithSharedId(shared_id) {
         try {
             const response = await fetch(`/api/get_shared_books/${shared_id}`, {
                 method: 'GET',
@@ -47,7 +47,7 @@ const CallAPIRapper = {
         }
     },
 
-    async registerIsbn(inputingIsbn) {
+    async registerNewIsbn(inputingIsbn) {
         try {
             if (inputingIsbn.length === 0) {
                 this.setState({ server_response: '入力欄が空です。' });
@@ -71,7 +71,7 @@ const CallAPIRapper = {
         }
     },
 
-    async changeReadState(book, new_read_state) {
+    async changeBookReadState(book, new_read_state) {
         try {
             let send_data = { book: book, new_read_state: new_read_state };
             const response = await fetch('/api/change_read_state', {
@@ -107,7 +107,7 @@ const CallAPIRapper = {
         }
     },
 
-    async shareUrlCopyToCrip() {
+    async getLoginingUserId() {
         try {
             const response = await fetch(`/api/get_user_id`, {
                 method: 'GET',

--- a/bookshelf_app/src/CallAPIRapper.js
+++ b/bookshelf_app/src/CallAPIRapper.js
@@ -73,7 +73,10 @@ const CallAPIRapper = {
 
     async changeBookReadState(book, new_read_state) {
         try {
-            let send_data = { book: book, new_read_state: new_read_state };
+            //サーバーサイドへはbook.detailを送らないようにします。
+            let send_book = JSON.parse(JSON.stringify(book));
+            send_book.detail = undefined;
+            let send_data = { book: send_book, new_read_state: new_read_state };
             const response = await fetch('/api/change_read_state', {
                 method: 'POST',
                 headers: {
@@ -91,7 +94,10 @@ const CallAPIRapper = {
 
     async deleteBook(book) {
         try {
-            let send_data = { book: book };
+            //サーバーサイドへはbook.detailを送らないようにします。
+            let send_book = JSON.parse(JSON.stringify(book));
+            send_book.detail = undefined;
+            let send_data = { book: send_book };
             const response = await fetch('/api/delete_book', {
                 method: 'POST',
                 headers: {

--- a/bookshelf_app/src/home.js
+++ b/bookshelf_app/src/home.js
@@ -25,26 +25,26 @@ class Bookshelf extends React.Component {
             books: [],
             mode_state: 0
         };
-        this.loadIsbn();
+        this.loadBooks();
     }
 
-    loadIsbn = async () => {
+    loadBooks = async () => {
         try {
-            const books = await CallAPIRapper.loadIsbn();
+            const books = await CallAPIRapper.loadBooks();
             this.setState({ books: books });
         } catch (error) {
             console.error(error);
         }
     }
 
-    registerIsbn = async (inputingIsbn) => {
+    registerNewBook = async (inputingIsbn) => {
         try {
             if (inputingIsbn.length === 0) {
                 this.setState({ server_response: '入力欄が空です。' });
                 return;
             }
 
-            const json = await CallAPIRapper.registerIsbn(inputingIsbn);
+            const json = await CallAPIRapper.registerNewIsbn(inputingIsbn);
             console.log("res: " + json.text);
             if (json.text === 'success') {
                 this.setState({ server_response: '登録できました！' });
@@ -63,9 +63,9 @@ class Bookshelf extends React.Component {
         }
     }
 
-    changeReadState = async (index, new_read_state) => {
+    changeBookReadState = async (index, new_read_state) => {
         try {
-            const json = await CallAPIRapper.changeReadState(this.state.books[index], new_read_state);
+            const json = await CallAPIRapper.changeBookReadState(this.state.books[index], new_read_state);
             console.log("res: " + json.text);
             if (json.text === 'success') {
                 this.setState({ server_response: '変更できました！' });
@@ -103,10 +103,8 @@ class Bookshelf extends React.Component {
 
     shareUrlCopyToCrip = async () => {
         try {
-            const response = await fetch(`/api/get_user_id`, {
-                method: 'GET',
-            })
-            const json = await response.json();
+
+            const json = await CallAPIRapper.getLoginingUserId();
             const shareUrl = `${window.location.origin}/shared_books/${json.user_id}`;
             navigator.clipboard.writeText(shareUrl).then(
                 () => {
@@ -133,7 +131,7 @@ class Bookshelf extends React.Component {
                 case 1:
                     return (
                         <BookAddState
-                            submitOnClick={this.registerIsbn}
+                            submitOnClick={this.registerNewBook}
                             books={this.state.books}
                         />
                     );
@@ -143,7 +141,7 @@ class Bookshelf extends React.Component {
                         changeReadState={(index) => {
                             let read_state = this.state.books[index].read_state;
                             let new_read_state = read_state < 2 ? read_state + 1 : 0;
-                            this.changeReadState(index, new_read_state);
+                            this.changeBookReadState(index, new_read_state);
                         }}
                     />);
                 case 3:

--- a/bookshelf_app/src/readOnly.js
+++ b/bookshelf_app/src/readOnly.js
@@ -14,17 +14,14 @@ class Bookshelf extends React.Component {
             mode_state: 0,
             user_name:''
         };
-        this.loadIsbn();
+        this.loadBooks();
     }
 
-    async loadIsbn() {
+    async loadBooks() {
         const path = window.location.pathname;
         const shared_id = path.split('/')[2];
         try {
-            const response = await fetch(`/api/get_shared_books/${shared_id}`, {
-                method: 'GET',
-            });
-            const books = await response.json();
+            const books = await CallAPIRapper.loadBooksWithSharedId(shared_id);
             for(const book of books){
                 book.detail = await getBookJson(book.isbn);
             }

--- a/bookshelf_app/src/readOnly.js
+++ b/bookshelf_app/src/readOnly.js
@@ -7,11 +7,7 @@ class Bookshelf extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            server_response: '',
-            inputingIsbn: '',
             books: [],
-            bookDetails: [],
-            mode_state: 0,
             user_name:''
         };
         this.loadBooks();


### PR DESCRIPTION
以下のfixを一度に行いました。
全てのクライアントjsが、クライアントのCallAPIRapperを使用して、サーバーAPI を呼び出すようにしました。
readOnlyの未使用変数を削除しました。
CallAPIRapperの関数をリネームしました。
CallAPIRapperから本のデータをサーバーに送る時、本の詳細を送らないようにしました。

本来これらを一つのプルリクにまとめるのはよろしくないですが。試しにやってみます。
close #17
close #18
